### PR TITLE
setting mime-type for image uploads, fixes previous bug where mime ty…

### DIFF
--- a/dist/BraftonLibrary/BraftonLibrary.php
+++ b/dist/BraftonLibrary/BraftonLibrary.php
@@ -46,7 +46,7 @@ function upload_image($img){
     $cfile .= ';filename='.$filename.';type='.$filetype;
     */
     // for PHP > 5.4 
-    $cfile = curl_file_create($filename, $filetype, $filename);
+    $cfile = curl_file_create($filename, $contenttype, $filename);
     $json_body = array(
         'files' => $cfile,
         'folder_paths'  => image_folder


### PR DESCRIPTION
…pe sent to Hubspot was showing as inode/x-empty intermittently #10